### PR TITLE
Remove RHEL repo download for RHV host

### DIFF
--- a/roles/v2v.ci/tasks/nmon_installation.yml
+++ b/roles/v2v.ci/tasks/nmon_installation.yml
@@ -57,9 +57,11 @@
         warn: no
       when: repo_file_exist.stat.exists == false
 
-    - name: Ensure ncurses packages are installed
-      delegate_to: "{{ v2v_item }}"
-      yum:
-        name: 'libncurses*'
-        state: present
+  when: v2v_item not in groups['ovirt_conversion_hosts']
+
+- name: Ensure ncurses packages are installed
+  delegate_to: "{{ v2v_item }}"
+  yum:
+    name: 'libncurses*'
+    state: present
   when: ansible_distribution_major_version == '8'


### PR DESCRIPTION
No need to download RHEL repo for RHV host, only for CFME VM - 
Fresh CFME VM doesn't have RHEL repo